### PR TITLE
Moved event data to additional Info

### DIFF
--- a/src/JSPerfProfiler.js
+++ b/src/JSPerfProfiler.js
@@ -34,8 +34,8 @@ export const clearPerfInfo = () => {
 export const timeAndLog = (fn, message, context, scope = 'General') => {
   /* istanbul ignore else */
   if (__DEV__) {
-    const event = new Event(scope, `${message} [${context}]`);
-    event.beginInterval(context);
+    const event = new Event(scope, message);
+    event.beginInterval(`${message} [${context}]`);
     executeInContext(context, fn);
     event.endInterval(Event.EventStatus.completed);
   } else {
@@ -66,7 +66,7 @@ export const attachRequire = () => {
       const context = contextStack.join('->');
       const skip = !message || message.indexOf('JS_require_') !== 0;
       message = message && message.substr('JS_require_'.length);
-      const event = !skip && new Event('Systrace', `require(${message}) [${context}]`);
+      const event = !skip && new Event('Systrace', `require()`);
       const finalDescription = `${message} ([${context}])`;
       eventsStack.push({event, skip});
       if (!skip) {

--- a/src/JSPerfProfiler.test.js
+++ b/src/JSPerfProfiler.test.js
@@ -76,7 +76,7 @@ describe('JSPerfProfiler', () => {
     JSPerfProfiler.$require.Systrace.endEvent();
     expect(mockEndInterval).toHaveBeenCalledTimes(1);
     expect(mockEventConstructor.mock.calls).toEqual([
-      ['Systrace', 'require() []'],
+      ['Systrace', 'require()']
     ]);
   });
 
@@ -110,9 +110,9 @@ describe('JSPerfProfiler', () => {
   it('should time and log events', () => {
     JSPerfProfiler.timeAndLog(() => {}, 'testMessage', 'testModule');
     expect(mockEventConstructor.mock.calls).toEqual([
-      ['General', 'testMessage [testModule]'],
+      ['General', 'testMessage'],
     ]);
-    expect(mockBeginInterval).toHaveBeenCalledWith('testModule');
+    expect(mockBeginInterval).toHaveBeenCalledWith('testMessage [testModule]');
     expect(mockEndInterval).toHaveBeenCalledWith(undefined);
   });
 


### PR DESCRIPTION
Moved event data to additional Info for better grouping in Detox Instruments. Detox Instruments now shows Additional Info column in list as well.
![screen shot 2018-12-10 at 18 28 43](https://user-images.githubusercontent.com/1361404/49746249-75279100-fca9-11e8-89fa-00dd95ed08cc.png)
