### PR TITLE
code: remove extraneous __DEV__

### DIFF
--- a/src/JSPerfProfiler.js
+++ b/src/JSPerfProfiler.js
@@ -182,7 +182,7 @@ const patchAppRegistry = () => {
 
 const defineProperty = (object, name, value) => {
   const descriptor = Object.getOwnPropertyDescriptor(object, name);
-  if (__DEV__ && descriptor) {
+  if (descriptor) {
     const backupName = `originalRN${name[0].toUpperCase()}${name.substr(1)}`;
     Object.defineProperty(object, backupName, descriptor);
   }


### PR DESCRIPTION
`defineProperty` is called only once, from `patchTimer`, and the latter occurs only in `attach` under __DEV__ conditional branch