### PR TITLE
fix: redundant error on consequent test re-runs

### DIFF
--- a/src/JSPerfProfiler.js
+++ b/src/JSPerfProfiler.js
@@ -198,6 +198,7 @@ const defineProperty = (object, name, value) => {
     value,
     enumerable: enumerable !== false,
     writable: writable !== false,
+    configurable: true,
   });
 };
 


### PR DESCRIPTION
Prevents redundant error message "Failed to attach profiler" in Jest logs on Node 10