### PR TITLE
fix: avoid exception in inline-requires mode

### DIFF
--- a/src/JSPerfProfiler.js
+++ b/src/JSPerfProfiler.js
@@ -77,7 +77,7 @@ export const attach = () => {
 export const attachRequire = () => {
   const eventsStack = [];
   /* istanbul ignore else */
-  if (require.Systrace) {
+  if (require.Systrace && Event) {
     require.Systrace.beginEvent = (message) => {
       const context = contextStack.join('->');
       const skip = !message || message.indexOf('JS_require_') !== 0;


### PR DESCRIPTION
The problem is that you get inside `beginEvent` function whenever you `require()` a module, but inside it, when you have inline-requires Babel plugin turned on, you have to `require('detox-instruments-react-native-utils')` to get the `Event` from it. But when you do that, you enter again inside `beginEvent` function in which you again try to get the `Event` and here we break — it is undefined.

If we interact with the exported `Event` before we set the `beginEvent` function, we will avoid the situation above.