### PR TITLE
Patch NativeEventEmitter to default export (RN 64)

### DIFF
--- a/src/JSPerfProfiler.js
+++ b/src/JSPerfProfiler.js
@@ -148,7 +148,7 @@ const patchBridge = () => {
 };
 
 const patchEventEmitter = () => {
-  const NativeEventEmitter = require('react-native/Libraries/EventEmitter/NativeEventEmitter');
+  const NativeEventEmitter = require('react-native/Libraries/EventEmitter/NativeEventEmitter').default;
   const orig = NativeEventEmitter.prototype.addListener;
 
   NativeEventEmitter.prototype.addListener = function (eventType, listener, ...a) {

--- a/src/JSPerfProfiler.test.js
+++ b/src/JSPerfProfiler.test.js
@@ -13,7 +13,10 @@ jest.mock('detox-instruments-react-native-utils', () => ({
   Event: mockEvent,
 }));
 
-jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter', () => require('events'));
+jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter', () => ({
+  __esModule: true,
+  default: require('events')
+}));
 
 jest.mock('react-native', () => {
   const apps = {};
@@ -160,7 +163,7 @@ describe('JSPerfProfiler', () => {
   });
 
   it('Should track context for EventEmitter', (done) => {
-    const NativeEventEmitter = require('react-native/Libraries/EventEmitter/NativeEventEmitter');
+    const NativeEventEmitter = require('react-native/Libraries/EventEmitter/NativeEventEmitter').default;
     const emitter = new NativeEventEmitter();
     JSPerfProfiler.executeInContext('testContext',"message", () => {
       emitter.addListener('tev', () => {


### PR DESCRIPTION
Due to this [change](https://github.com/facebook/react-native/commit/9a5ab9e36625e6bf6ffa056ff1c2c0feaa0e2d83#diff-9f250e6d8a5ec553d894b660a762e5975e048fcb822ece9d1af7a72d93b3cb71) in `NativeEventEmitter` our code had to change.